### PR TITLE
Remove cloudformation:DescribeStacks from deny section

### DIFF
--- a/cloud_health_policy.json
+++ b/cloud_health_policy.json
@@ -64,7 +64,6 @@
       "Action": [
         "autoscaling:DescribeLaunchConfigurations",
         "ec2:DescribeInstanceAttribute",
-        "cloudformation:DescribeStacks",
         "sdb:Select"
       ],
       "Resource": [


### PR DESCRIPTION
Seems redundant and doesn't do anything by allowing and then denying this permission, I feel that `cloudformation:DescribeStacks` is safe enough to just allow vs denying it