### PR TITLE
Adding describe report definitions permission

### DIFF
--- a/cloud_health_policy.json
+++ b/cloud_health_policy.json
@@ -17,6 +17,7 @@
         "cloudwatch:Describe*",
         "cloudwatch:Get*",
         "cloudwatch:List*",
+        "cur:DescribeReportDefinitions",
         "dynamodb:DescribeTable",
         "dynamodb:ListTables",
         "ec2:Describe*",


### PR DESCRIPTION
The permission does this:

http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/describe-report-definitions.html

And helps enable this:

https://help.cloudhealthtech.com/administration/aws/enable-cost-and-usage-report.html